### PR TITLE
Remove dead code and unused configuration

### DIFF
--- a/helm/nuska/templates/configmap.yaml
+++ b/helm/nuska/templates/configmap.yaml
@@ -19,14 +19,10 @@ data:
     management.endpoint.health.group.readiness.include=readinessState
     management.endpoint.prometheus.enabled=true
     management.endpoints.web.exposure.include=info,health,prometheus
-    management.health.pubsub.enabled=false
 
     # Logging
     logging.config=classpath:logback.xml
     logging.level.no.entur=INFO
-    logging.level.no.entur.antu=INFO
-    logging.level.org.apache=INFO
-    logging.level.org.apache.camel.component.http.HttpComponent=WARN
 
     #OAuth2 Resource Server
     nuska.oauth2.resourceserver.auth0.ror.claim.namespace=https://ror.entur.io/

--- a/src/main/java/no/entur/nuska/NuskaController.java
+++ b/src/main/java/no/entur/nuska/NuskaController.java
@@ -58,7 +58,7 @@ class NuskaController implements TimetableDataApi {
     String importKey,
     String acceptHeader
   ) {
-    return downloadDataset(codespace, importKey, acceptHeader);
+    return downloadDataset(codespace, importKey);
   }
 
   @Override
@@ -66,7 +66,7 @@ class NuskaController implements TimetableDataApi {
     String codespace,
     String acceptHeader
   ) {
-    return downloadDataset(codespace, null, acceptHeader);
+    return downloadDataset(codespace, null);
   }
 
   @Override
@@ -112,16 +112,8 @@ class NuskaController implements TimetableDataApi {
 
   private ResponseEntity<Resource> downloadDataset(
     String codespace,
-    String importKey,
-    String acceptHeader
+    String importKey
   ) {
-    // TODO log Accept header for debugging. To be removed.
-    if (acceptHeader != null) {
-      LOGGER.info("Client accepted content types: {}", acceptHeader);
-    } else {
-      LOGGER.info("Client did not specify Accept header.");
-    }
-
     new RequestValidator(codespace, importKey).validate();
 
     LOGGER.info(

--- a/src/main/java/no/entur/nuska/NuskaException.java
+++ b/src/main/java/no/entur/nuska/NuskaException.java
@@ -6,10 +6,6 @@ public class NuskaException extends RuntimeException {
     super(message);
   }
 
-  public NuskaException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
   public NuskaException(Exception e) {
     super(e);
   }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -32,7 +32,6 @@
                             },
                             "message": "%message\n%ex{full}",
                             "severity": "%level",
-                            "breadcrumb": "%X{camel.breadcrumbId}",
                             "reportLocation": {
                                 "filePath": "%logger",
                                 "lineNumber": "%line",
@@ -47,9 +46,6 @@
         <logger name="com" level="INFO"/>
         <logger name="no" level="INFO"/>
         <logger name="org" level="INFO"/>
-
-        <!--- Reducing verbosity of Jackson startup logs-->
-        <logger name="org.apache.camel.component.jackson.JacksonDataFormat" level="WARN" />
 
         <root level="INFO">
             <appender-ref ref="console"/>


### PR DESCRIPTION
## Summary
- Drop unused `NuskaException(String, Throwable)` constructor.
- Remove leftover `TODO` Accept-header debug logging in `NuskaController` and the now-unused `acceptHeader` parameter on the private `downloadDataset` helper. Public overrides keep it as required by the generated OpenAPI interface.
- Clean up `logback.xml`: drop the Camel breadcrumb MDC field and the `org.apache.camel.component.jackson.JacksonDataFormat` logger. Camel is not a dependency of this service.
- Clean up the Helm configmap: drop `management.health.pubsub.enabled`, `logging.level.no.entur.antu`, `logging.level.org.apache`, and `logging.level.org.apache.camel.component.http.HttpComponent`. None apply to this service.

## Test plan
- [x] `mvn -P prettierSkip test` (7 tests pass)
- [ ] CI (`mvn verify`) green