### PR TITLE
Upgrade entur/gha-api reusable workflows from v4 to v6

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,19 +49,18 @@ jobs:
                   -Dsonar.token=${SONAR_TOKEN}
   Openapi-lint:
     needs: [ maven-verify ]
-    uses: entur/gha-api/.github/workflows/lint.yml@v4
+    uses: entur/gha-api/.github/workflows/lint.yml@v6
     secrets: inherit
     with:
-      spec: 'src/main/resources/openapi/openapi.yaml'
+      path: 'src/main/resources/openapi/openapi.yaml'
       upload_to_bucket: ${{ github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
   openapi-publish:
     if: github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [ Openapi-lint ]
-    uses: entur/gha-api/.github/workflows/publish.yml@v4
+    uses: entur/gha-api/.github/workflows/publish.yml@v6
     secrets: inherit
     with:
-      visibility: 'partner'
-      spec: 'src/main/resources/openapi/openapi.yaml'
+      path: 'src/main/resources/openapi/openapi.yaml'
 
   docker-build:
     if: github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -3,6 +3,10 @@ info:
   title: Raw Timetable Data
   description: Provide access to the original NeTEx datasets uploaded by data providers
   version: '1.0'
+  x-entur-metadata:
+    id: raw-timetable-data
+    audience: partner
+    owner: team-ror
 servers:
 - url: https://api.entur.io/timetable/v1/timetable-data
   description: Production

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Raw Timetable Data
   description: Provide access to the original NeTEx datasets uploaded by data providers
-  version: '1.0'
+  version: '1.0.0'
   x-entur-metadata:
     id: raw-timetable-data
     audience: partner


### PR DESCRIPTION
## Summary
Upgrade `entur/gha-api` `lint.yml` and `publish.yml` reusable workflows from `@v4` to `@v6`, and adapt to the breaking changes introduced in [v6.0.0](https://github.com/entur/gha-api/releases/tag/v6.0.0).

Breaking changes applied (matches the pattern used in the nisaba upgrade: entur/nisaba@888560c and entur/nisaba@9f75eeb):
- Input renamed: `spec` → `path` on both `lint.yml` and `publish.yml`.
- Input removed: `visibility` on `publish.yml`. The audience is now declared inside the spec under `info.x-entur-metadata.audience` (`partner` preserves the previous `visibility: 'partner'` behaviour).
- `info.x-entur-metadata` is now required by `gha-api/publish`. Added `id`, `audience`, and `owner`.

## Test plan
- [ ] `Openapi-lint` job passes on `@v6` (will verify in CI)
- [ ] `openapi-publish` job runs on push to main