### PR TITLE
Replace deprecated APIs in OAuth2 security configuration

### DIFF
--- a/src/main/java/no/entur/nuska/config/oauth2/NuskaMultiIssuerAuthenticationManagerResolver.java
+++ b/src/main/java/no/entur/nuska/config/oauth2/NuskaMultiIssuerAuthenticationManagerResolver.java
@@ -30,8 +30,10 @@ public class NuskaMultiIssuerAuthenticationManagerResolver
   ) {
     super(
       enturInternalAuth0Audience,
+      null,
       enturInternalAuth0Issuer,
       enturPartnerAuth0Audience,
+      null,
       enturPartnerAuth0Issuer,
       null,
       null,

--- a/src/main/java/no/entur/nuska/config/oauth2/NuskaWebSecurityConfiguration.java
+++ b/src/main/java/no/entur/nuska/config/oauth2/NuskaWebSecurityConfiguration.java
@@ -11,7 +11,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -60,23 +59,15 @@ public class NuskaWebSecurityConfiguration {
       .csrf(AbstractHttpConfigurer::disable)
       .authorizeHttpRequests(authz ->
         authz
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/timetable-data/openapi.yaml")
-          )
+          .requestMatchers("/timetable-data/openapi.yaml")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/prometheus")
-          )
+          .requestMatchers("/actuator/prometheus")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/health"))
+          .requestMatchers("/actuator/health")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/health/liveness")
-          )
+          .requestMatchers("/actuator/health/liveness")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/health/readiness")
-          )
+          .requestMatchers("/actuator/health/readiness")
           .permitAll()
           .anyRequest()
           .authenticated()


### PR DESCRIPTION
## Summary
- Switch `NuskaMultiIssuerAuthenticationManagerResolver` to the new non-deprecated 9-arg parent constructor exposed by `org.entur.ror.helpers:oauth2:5.50.0` (the old 7-arg form is `@Deprecated`).
- Replace `AntPathRequestMatcher.antMatcher(...)` (deprecated and marked for removal in Spring Security 6.x) with plain path strings passed directly to `requestMatchers(...)`, and drop the now-unused import.

## Test plan
- [x] `mvn clean test` — BUILD SUCCESS, 7/7 tests pass
- [x] No `[deprecation]` warnings emitted under `-Dmaven.compiler.showDeprecation=true`