### PR TITLE
Document 406 response and required Accept media type for dataset downloads

### DIFF
--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -125,10 +125,18 @@ paths:
           type: string
       - name: Accept
         in: header
-        description: Media type(s) that is/are acceptable for the response
+        description: >-
+          Media type acceptable for the response. The dataset is returned as a
+          binary file, so this must be `application/octet-stream` (or a wildcard
+          such as `*/*`). Any other value — for example `application/zip`, even
+          though the payload is a ZIP archive — results in a `406 Not Acceptable`
+          response. If the header is omitted it defaults to
+          `application/octet-stream`.
         required: false
         schema:
           type: string
+          default: application/octet-stream
+          example: application/octet-stream
       responses:
         '200':
           description: Successfully retrieved the dataset file
@@ -178,6 +186,12 @@ paths:
                     errorCode: NOT_FOUND
                     message: Dataset not found for the specified codespace and import
                       key
+        '406':
+          description: >-
+            Not Acceptable - the media type requested in the `Accept` header
+            cannot be produced. The dataset is only served as
+            `application/octet-stream`; requesting another type such as
+            `application/zip` triggers this response.
         '500':
           description: Internal Server Error
           content:
@@ -204,10 +218,18 @@ paths:
           type: string
       - name: Accept
         in: header
-        description: Media type(s) that is/are acceptable for the response
+        description: >-
+          Media type acceptable for the response. The dataset is returned as a
+          binary file, so this must be `application/octet-stream` (or a wildcard
+          such as `*/*`). Any other value — for example `application/zip`, even
+          though the payload is a ZIP archive — results in a `406 Not Acceptable`
+          response. If the header is omitted it defaults to
+          `application/octet-stream`.
         required: false
         schema:
           type: string
+          default: application/octet-stream
+          example: application/octet-stream
       responses:
         '200':
           description: Successfully retrieved the latest dataset file
@@ -256,6 +278,12 @@ paths:
                   value:
                     errorCode: NOT_FOUND
                     message: No latest dataset found for the specified codespace
+        '406':
+          description: >-
+            Not Acceptable - the media type requested in the `Accept` header
+            cannot be produced. The dataset is only served as
+            `application/octet-stream`; requesting another type such as
+            `application/zip` triggers this response.
         '500':
           description: Internal Server Error
           content:


### PR DESCRIPTION
## Why

Based on user feedback: an API consumer got a **406 Not Acceptable** because they sent `Accept: application/zip` when downloading a dataset. The endpoints actually produce `application/octet-stream`. Two documentation gaps made this easy to get wrong (especially for AI-assisted clients reading the spec):

1. The `Accept` header was documented only generically ("Media type(s) that is/are acceptable for the response") — it never said which media type is actually required.
2. `406` was not listed among the possible response codes.

## Changes

Applies to both binary-download operations (`getDataset`, `getLatestDataset`) in `openapi.yaml`:

- **`Accept` header** now describes the concrete requirement: it must be `application/octet-stream` (or a wildcard), notes that other values such as `application/zip` yield a 406, and adds `default`/`example` of `application/octet-stream` so generated clients send the right header automatically.
- **`406 Not Acceptable`** is now documented as a possible response, with a description of the cause and remedy.

The JSON listing endpoint (`getDatasetVersions`) is left unchanged.

